### PR TITLE
Dynamically resolve backend hostnames during runtime

### DIFF
--- a/config/haproxy.cfg
+++ b/config/haproxy.cfg
@@ -9,6 +9,11 @@ defaults
 	timeout connect 4s
 	timeout server 30m
 	timeout check 5s
+	# never fail on address resolution
+	default-server init-addr none
+
+resolvers docker_resolver
+	nameserver dns 127.0.0.11:53
 
 frontend master_postgresql
 	bind *:5000
@@ -24,18 +29,18 @@ frontend patroni_api
 
 backend backend_master
 	option httpchk OPTIONS /master
-	server dbnode1 dbnode1:5432 maxconn 100 check port 8008
-	server dbnode2 dbnode2:5432 maxconn 100 check port 8008
-	server dbnode3 dbnode3:5432 maxconn 100 check port 8008
+	server dbnode1 dbnode1:5432 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4
+	server dbnode2 dbnode2:5432 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4
+	server dbnode3 dbnode3:5432 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4
 
 backend backend_replicas
 	option httpchk OPTIONS /replica
-	server dbnode1 dbnode1:5432 maxconn 100 check port 8008
-	server dbnode2 dbnode2:5432 maxconn 100 check port 8008
-	server dbnode3 dbnode3:5432 maxconn 100 check port 8008
+	server dbnode1 dbnode1:5432 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4
+	server dbnode2 dbnode2:5432 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4
+	server dbnode3 dbnode3:5432 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4
 
 backend backend_api
 	option httpchk OPTIONS /master
-	server dbnode1 dbnode1:8008 maxconn 100 check port 8008
-	server dbnode2 dbnode2:8008 maxconn 100 check port 8008
-	server dbnode3 dbnode3:8008 maxconn 100 check port 8008
+	server dbnode1 dbnode1:8008 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4
+	server dbnode2 dbnode2:8008 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4
+	server dbnode3 dbnode3:8008 maxconn 100 check port 8008 resolvers docker_resolver resolve-prefer ipv4


### PR DESCRIPTION
This gets around an edge case which leads to a dangerous fragility:

If the haproxy container is restarted while one of the db nodes is (temporarily) down, it aborts during startup. That's because that db container's hostname is not known during haproxy startup.

This change allows starting up haproxy regardless if it can resolve all hostnames immediately.